### PR TITLE
Remove skip_switch option

### DIFF
--- a/.openshift/action_hooks/pre_start_python-2.7
+++ b/.openshift/action_hooks/pre_start_python-2.7
@@ -41,8 +41,8 @@ fi
 
 # Clone the repo if not already exists
 if [ ! -d ${VICTIMS_LOCAL_REPO} ]; then
-    echo "$LOG_PREFIX Cloning victims-web from $VICTIMS_GIT_URL"
-    git clone $VICTIMS_GIT_URL ${VICTIMS_LOCAL_REPO}
+    echo "$LOG_PREFIX Cloning victims-web branch $VICTIMS_GIT_BRANCH from $VICTIMS_GIT_URL"
+    git clone -b ${VICTIMS_GIT_BRANCH} $VICTIMS_GIT_URL ${VICTIMS_LOCAL_REPO}
 fi
 
 if [ -z ${SKIP_SWITCH} ]; then

--- a/.openshift/action_hooks/pre_start_python-2.7
+++ b/.openshift/action_hooks/pre_start_python-2.7
@@ -45,16 +45,6 @@ if [ ! -d ${VICTIMS_LOCAL_REPO} ]; then
     git clone -b ${VICTIMS_GIT_BRANCH} $VICTIMS_GIT_URL ${VICTIMS_LOCAL_REPO}
 fi
 
-if [ -z ${SKIP_SWITCH} ]; then
-    # Switch only if SKIP_SWITCH is not defined
-    echo "$LOG_PREFIX Switching to branch ${VICTIMS_GIT_BRANCH}"
-    (cd ${VICTIMS_LOCAL_REPO} && git fetch)
-    (cd ${VICTIMS_LOCAL_REPO} && git checkout ${VICTIMS_GIT_BRANCH})
-    (cd ${VICTIMS_LOCAL_REPO} && git pull --rebase origin ${VICTIMS_GIT_BRANCH})
-else
-    echo "$LOG_PREFIX Skipping branch switching"
-fi
-
 # reinstall victims-web on start
 echo "$LOG_PREFIX Updating dependencies for victims-web ..."
 pip install --use-mirrors -e ${VICTIMS_LOCAL_REPO} >> ${PIP_LOG} 2>&1

--- a/config/victimsweb.env
+++ b/config/victimsweb.env
@@ -5,7 +5,3 @@ VICTIMS_GIT_BRANCH=master
 
 # Enable this to trigger a clean every start
 # VICTIMS_GIT_CLEAN=1
-
-# Enable this to skip the switching and update of the local branch
-# This is useful if you are debugging the app itself
-# SKIP_SWITCH=1


### PR DESCRIPTION
Currently in the openshift app there is the option to skip switching branches in the python pre-start action hook, this wouldn't be necessary if the git clone command simply grabs the needed branch without having to git clone the master branch and then perform a branch switch if needed that would then result in the previous branch just sitting there not being used.
